### PR TITLE
[WEB-17] Add analytics for links and buttons

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -6,7 +6,7 @@ import React from 'react'
 
 
 // Component imports
-import { Link } from '../routes'
+import Link from './Link'
 import Nav from './Nav'
 
 
@@ -37,7 +37,10 @@ export default (props) => (
         Close
       </label>
 
-      <Link href="/">
+      <Link
+        category="Navigation"
+        route="/"
+        label="Brand">
         <a><div className="brand" /></a>
       </Link>
 

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -23,7 +23,7 @@ export default (props) => (
     <header role="banner">
       <label
         className="button success"
-        data-openNav
+        data-opennav
         htmlFor="application-banner-control">
         <FontAwesomeIcon icon="bars" fixedWidth />
         Menu
@@ -31,7 +31,7 @@ export default (props) => (
 
       <label
         className="button secondary"
-        data-closeNav
+        data-closenav
         htmlFor="application-banner-control">
         <FontAwesomeIcon icon="times" fixedWidth />
         Close

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,0 +1,53 @@
+// Component imports
+import TrackableComponent from './TrackableComponent'
+
+
+
+
+
+class Button extends TrackableComponent {
+  /***************************************************************************\
+    Private Methods
+  \***************************************************************************/
+
+  _onClick (event) {
+    const { onClick } = this.props
+
+    this._fireEvent()
+
+    if (onClick) {
+      onClick(event)
+    }
+  }
+
+
+
+
+
+  /***************************************************************************\
+    Public Methods
+  \***************************************************************************/
+
+  constructor (props) {
+    super(props)
+
+    this._bindMethods(['_onClick'])
+  }
+
+  render () {
+    return (
+      <button
+        {...this.renderProps}
+        onClick={this._onClick}>
+        {this.props.children}
+      </button>
+    )
+  }
+}
+
+
+
+
+
+export default Button
+export { Button }

--- a/components/Form.js
+++ b/components/Form.js
@@ -49,4 +49,10 @@ class Form extends TrackableComponent {
 
 
 
+Form.defaultProps = { action: 'submit' }
+
+
+
+
+
 export default Form

--- a/components/Form.js
+++ b/components/Form.js
@@ -1,0 +1,52 @@
+// Component imports
+import TrackableComponent from './TrackableComponent'
+
+
+
+
+
+class Form extends TrackableComponent {
+  /***************************************************************************\
+    Private Methods
+  \***************************************************************************/
+
+  _onSubmit (event) {
+    const { onSubmit } = this.props
+
+    this._fireEvent()
+
+    if (onSubmit) {
+      onSubmit(event)
+    }
+  }
+
+
+
+
+
+  /***************************************************************************\
+    Public Methods
+  \***************************************************************************/
+
+  constructor (props) {
+    super(props)
+
+    this._bindMethods(['_onSubmit'])
+  }
+
+  render () {
+    return (
+      <form
+        {...this.renderProps}
+        onSubmit={this._onSubmit}>
+        {this.props.children}
+      </form>
+    )
+  }
+}
+
+
+
+
+
+export default Form

--- a/components/GroupCard.js
+++ b/components/GroupCard.js
@@ -30,8 +30,9 @@ const GroupCard = (props) => {
       <header>
         <h2 title={name}>
           <Link
-            category="Group Search"
-            label="Group Card"
+            action="view-result"
+            category="Groups"
+            label="Search"
             route="group profile"
             params={{ id: slug }}>
             <a>{name}</a>

--- a/components/GroupCard.js
+++ b/components/GroupCard.js
@@ -1,8 +1,6 @@
 // Module imports
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-// import FontAwesomeIcon from '@fortawesome/react-fontawesome'
-import Link from 'next/link'
 import React from 'react'
 
 
@@ -10,133 +8,62 @@ import React from 'react'
 
 // Component imports
 import { actions } from '../store'
-import Component from './Component'
+import { Link } from '../routes'
 
 
 
 
 
-class GroupCard extends Component {
-  /***************************************************************************\
-    Private Methods
-  \***************************************************************************/
+const GroupCard = (props) => {
+  const { group } = props
 
-  // async _requestToJoinGroup () {
-  //   const {
-  //     group,
-  //     requestToJoinGroup,
-  //   } = this.props
+  const {
+    description,
+    games,
+    members,
+    name,
+    slug,
+  } = group.attributes
 
-  //   this.setState({ requestingToJoin: true })
+  return (
+    <div className="card">
+      <header>
+        <h2 title={name}>
+          <Link
+            route="group profile"
+            params={{ id: slug }}>
+            <a>{name}</a>
+          </Link>
+        </h2>
 
-  //   const { status } = await requestToJoinGroup(group.id)
+        <small>{members} members</small>
+      </header>
 
-  //   setTimeout(() => {
-  //     this.setState({
-  //       joinRequestSent: status,
-  //       requestingToJoin: false,
-  //     })
-  //   }, 500)
-  // }
+      <div className="content">
+        {!!description && (
+          <p>{description}</p>
+        )}
 
+        {!description && (
+          <p><em>No description</em></p>
+        )}
 
+        {games && (
+          <header>
+            <h3>Games:</h3>
+          </header>
+        )}
 
-
-
-  /***************************************************************************\
-    Public Methods
-  \***************************************************************************/
-
-  constructor (props) {
-    super(props)
-
-    // this._bindMethods(['_requestToJoinGroup'])
-
-    this.state = {
-      // joinRequestSent: false,
-      // requestingToJoin: false,
-    }
-  }
-
-  render () {
-    const { group } = this.props
-    // const {
-    //   joinRequestSent,
-    //   requestingToJoin,
-    // } = this.state
-
-    const { id } = group
-    const {
-      description,
-      games,
-      members,
-      name,
-    } = group.attributes
-    // const memberStatus = group.attributes.mamber_status
-
-    return (
-      <div className="card">
-        <header>
-          <h2 title={name}>{name}</h2>
-
-          <small>{members} members</small>
-        </header>
-
-        <div className="content">
-          {!!description && (
-            <p>{description}</p>
-          )}
-
-          {!description && (
-            <p><em>No description</em></p>
-          )}
-
-          {games && (
-            <header>
-              <h3>Games:</h3>
-            </header>
-          )}
-
-          {games && (
-            <ul className="comma-separated inline">
-              {games.map(game => (
-                <li key={game}>{game}</li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <footer>
-          <menu type="toolbar">
-            <div className="primary">
-              <Link route="group profile" params={{ id }}>
-                <a className="button info">
-                  Learn more
-                </a>
-              </Link>
-            </div>
-
-            {/* <div className="secondary">
-              <button
-                className="secondary"
-                disabled={requestingToJoin || joinRequestSent}
-                onClick={this._requestToJoinGroup}>
-                {(!requestingToJoin && !joinRequestSent && !(memberStatus === 'pending')) && 'Join'}
-
-                {((!requestingToJoin && joinRequestSent) || (memberStatus === 'pending')) && (
-                  <span><FontAwesomeIcon icon="check"/> Request Sent</span>
-                )}
-
-                {requestingToJoin && (
-                  <span><FontAwesomeIcon icon="spinner" pulse /> Sending request...</span>
-                )}
-              </button>
-            </div> */}
-          </menu>
-        </footer>
+        {games && (
+          <ul className="comma-separated inline">
+            {games.map(game => (
+              <li key={game}>{game}</li>
+            ))}
+          </ul>
+        )}
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 

--- a/components/GroupCard.js
+++ b/components/GroupCard.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 // Component imports
 import { actions } from '../store'
-import { Link } from '../routes'
+import Link from './Link'
 
 
 
@@ -30,6 +30,8 @@ const GroupCard = (props) => {
       <header>
         <h2 title={name}>
           <Link
+            category="Group Search"
+            label="Group Card"
             route="group profile"
             params={{ id: slug }}>
             <a>{name}</a>

--- a/components/GroupProfilePanels/GroupDetailsPanel.js
+++ b/components/GroupProfilePanels/GroupDetailsPanel.js
@@ -7,7 +7,7 @@ import React from 'react'
 
 
 // Component imports
-import { Link } from '../../routes'
+import Link from '../Link'
 import { convertObjectToQueryParams } from '../../helpers'
 import Component from '../Component'
 import ShareableLink from '../ShareableLink'
@@ -69,7 +69,11 @@ class GroupDetailsPanel extends Component {
           <div className="section-content">
             <div className="input-group">
               <div className="input-group">
-                <Link href={`//twitter.com/intent/tweet${convertObjectToQueryParams(twitterShareParams)}`}>
+                <Link
+                  category="Group Profile"
+                  href={`//twitter.com/intent/tweet${convertObjectToQueryParams(twitterShareParams)}`}
+                  label="Twitter Share"
+                  value={group.id}>
                   <a className="button secondary">
                     <FontAwesomeIcon icon={['fab', 'twitter']} fixedWidth />
                   </a>

--- a/components/GroupProfilePanels/GroupDetailsPanel.js
+++ b/components/GroupProfilePanels/GroupDetailsPanel.js
@@ -70,9 +70,10 @@ class GroupDetailsPanel extends Component {
             <div className="input-group">
               <div className="input-group">
                 <Link
-                  category="Group Profile"
+                  action="share::twitter"
+                  category="Groups"
                   href={`//twitter.com/intent/tweet${convertObjectToQueryParams(twitterShareParams)}`}
-                  label="Twitter Share"
+                  label="Profile"
                   value={group.id}>
                   <a className="button secondary">
                     <FontAwesomeIcon icon={['fab', 'twitter']} fixedWidth />

--- a/components/GroupProfilePanels/GroupSettingsPanel.js
+++ b/components/GroupProfilePanels/GroupSettingsPanel.js
@@ -14,6 +14,7 @@ import Switch from 'rc-switch'
 import { actions } from '../../store'
 import { convertStringToSlug } from '../../helpers'
 import AddressInput from '../AddressInput'
+import Form from '../Form'
 import Component from '../Component'
 import ValidatedInput from '../ValidatedInput'
 
@@ -143,7 +144,11 @@ class GroupSettingsPanel extends Component {
 
     return (
       <section className="settings">
-        <form onSubmit={this._handleSubmit}>
+        <Form
+          action="update"
+          category="Groups"
+          label="Settings"
+          onSubmit={this._handleSubmit}>
           <fieldset>
             <label htmlFor="name">
               Group name
@@ -229,7 +234,8 @@ class GroupSettingsPanel extends Component {
             <div className="primary">
               <button
                 className="success"
-                disabled={submitting || !this._isValid()}>
+                disabled={submitting || !this._isValid()}
+                type="submit">
                 {!submitting && 'Save'}
 
                 {submitting && (
@@ -238,7 +244,7 @@ class GroupSettingsPanel extends Component {
               </button>
             </div>
           </menu>
-        </form>
+        </Form>
       </section>
     )
   }

--- a/components/Head.js
+++ b/components/Head.js
@@ -1,3 +1,4 @@
+// Module imports
 import NextHead from 'next/head'
 import NProgress from 'nprogress'
 import React from 'react'
@@ -6,6 +7,7 @@ import React from 'react'
 
 
 
+// Component imports
 import { Router } from '../routes'
 import appStylesheet from '../scss/app.scss'
 import libStylesheet from '../scss/lib.scss'

--- a/components/Head.js
+++ b/components/Head.js
@@ -27,7 +27,7 @@ Router.onRouteChangeError = () => {
 }
 
 Router.onRouteChangeComplete = () => {
-  if (window.twttr) {
+  if ('twttr' in window) {
     window.twttr.widgets.load()
   }
 

--- a/components/Link.js
+++ b/components/Link.js
@@ -43,8 +43,6 @@ class TrackableLink extends TrackableComponent {
     super(props)
 
     this._bindMethods(['_handleClick'])
-
-    console.log(this)
   }
 
   render () {

--- a/components/Link.js
+++ b/components/Link.js
@@ -1,0 +1,96 @@
+// Component Imports
+import React from 'react'
+
+
+
+
+
+// Component Imports
+import { Router } from '../routes'
+import TrackableComponent from './TrackableComponent'
+
+
+
+
+
+class TrackableLink extends TrackableComponent {
+  /***************************************************************************\
+    Private Methods
+  \***************************************************************************/
+
+  _handleClick (event) {
+    const {
+      params,
+      route,
+    } = this.props
+
+    event.preventDefault()
+
+    this._fireEvent()
+
+    Router.pushRoute(route, params)
+  }
+
+
+
+
+
+  /***************************************************************************\
+   Public Methods
+   \***************************************************************************/
+
+  constructor (props) {
+    super(props)
+
+    this._bindMethods(['_handleClick'])
+
+    console.log(this)
+  }
+
+  render () {
+    return (
+      <React.Fragment>
+        {this.renderProps.children}
+      </React.Fragment>
+    )
+  }
+
+
+
+
+
+  /***************************************************************************\
+    Getters
+  \***************************************************************************/
+
+  get renderProps () {
+    const renderProps = super.renderProps
+    const { children } = renderProps
+
+    const newProps = { onClick: this._handleClick }
+
+    if (children.type === 'a') {
+      newProps.href = renderProps.route
+    }
+
+    return {
+      ...renderProps,
+      children: React.cloneElement(children, newProps),
+    }
+  }
+}
+
+
+
+
+
+TrackableLink.defaultProps = {
+  action: 'click',
+}
+
+
+
+
+
+export default TrackableLink
+export { TrackableLink }

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -10,7 +10,7 @@ import React from 'react'
 
 // Module imports
 import { actions } from '../store'
-import { Link } from '../routes'
+import Link from './Link'
 import Avatar from './Avatar'
 import Component from './Component'
 
@@ -24,26 +24,16 @@ const navItems = [
     title: 'Groups',
     subnav: [
       {
-        href: '/my/groups',
+        route: '/my/groups',
         title: 'My Groups',
       },
 
       {
-        href: '/groups/search',
+        route: '/groups/search',
         title: 'Search',
       },
     ],
   },
-
-  // {
-  //   title: 'Content',
-  //   subnav: [
-  //     {
-  //       href: '/my/characters',
-  //       title: 'Characters',
-  //     },
-  //   ],
-  // },
 
   {
     condition: ({ loggedIn }) => loggedIn && (loggedIn !== 'error'),
@@ -63,79 +53,20 @@ const navItems = [
       return 'Loading...'
     },
     subnav: [
-      // {
-      //   href: '/my/activity-feed',
-      //   title: 'Activity Feed',
-      // },
       {
         route: 'user profile current',
         title: 'My Profile',
       },
       {
-        href: '/logout',
+        route: '/logout',
         title: 'Logout',
       },
     ],
   },
 
-  // {
-  //   title: 'GM Tools',
-  //   subnav: [
-  //     {
-  //       href: '/roadmap#3005240', // '/groups/manage',
-  //       title: 'Groups',
-  //     },
-
-  //     {
-  //       href: '/roadmap#3005241', // '/gm/dungeons',
-  //       title: 'Dungeons',
-  //     },
-
-  //     {
-  //       href: '/roadmap#3005245', // '/gm/encounters',
-  //       title: 'Encounters',
-  //     },
-
-  //     // {
-  //     //   href: '/roadmap#3005240', // '/gm/monsters',
-  //     //   title: 'Monsters',
-  //     // },
-
-  //     {
-  //       href: '/roadmap#3005248', // '/gm/npcs',
-  //       title: 'NPCs',
-  //     },
-
-  //     {
-  //       href: '/roadmap#3005243', // '/gm/treasure',
-  //       title: 'Treasure',
-  //     },
-  //   ],
-  // },
-
-  // {
-  //   title: 'About',
-  //   subnav: [
-  //     // {
-  //     //   href: '/mission-statement',
-  //     //   title: 'Our Mission',
-  //     // },
-
-  //     {
-  //       href: '/roadmap',
-  //       title: 'Roadmap',
-  //     },
-
-  //     {
-  //       href: '/contact',
-  //       title: 'Contact Us',
-  //     },
-  //   ],
-  // },
-
   {
     condition: props => !props.loggedIn || (props.loggedIn === 'error'),
-    href: '/login',
+    route: '/login',
     title: 'Login/Sign Up',
   },
 ]
@@ -195,7 +126,7 @@ class Nav extends Component {
     const key = item.key || renderedItemTitle.toLowerCase().replace(/\s/g, '-')
 
     for (const [itemKey, itemValue] of Object.entries(item)) {
-      if (/^href|as|route|params$/gi.test(itemKey)) {
+      if (/^label|route|params$/gi.test(itemKey)) {
         itemWithOnlyLinkProps[itemKey] = itemValue
       }
     }
@@ -223,7 +154,14 @@ class Nav extends Component {
           type="radio" />
       )
     } else {
-      renderedItemTitle = (<Link {...itemWithOnlyLinkProps}><a>{renderedItemTitle}</a></Link>)
+      renderedItemTitle = (
+        <Link
+          {...itemWithOnlyLinkProps}
+          category="Navigation"
+          label={renderedItemTitle}>
+          <a>{renderedItemTitle}</a>
+        </Link>
+      )
     }
 
     return (

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -22,6 +22,7 @@ class Pagination extends Component {
     const {
       category,
       currentPage,
+      label,
       onPageChange,
       pagesToRender,
       totalPageCount,
@@ -48,12 +49,12 @@ class Pagination extends Component {
         pageLinks.push((
           <li key={pageNumber}>
             <Button
+              action={`page::${pageNumber}`}
               category={category}
               className={classes.join(', ')}
               disabled={isCurrentPage}
-              label="Go To Page"
-              onClick={() => onPageChange(pageNumber)}
-              value={pageNumber}>
+              label={label}
+              onClick={() => onPageChange(pageNumber)}>
               {pageNumber}
             </Button>
           </li>
@@ -84,6 +85,7 @@ class Pagination extends Component {
     const {
       category,
       currentPage,
+      label,
       onPageChange,
       showPageLinks,
       totalPageCount,
@@ -92,10 +94,11 @@ class Pagination extends Component {
     return (
       <nav className="pagination">
         <Button
+          action="page::previous"
           category={category}
           className="previous secondary"
           disabled={currentPage === 1}
-          label="Previous Page"
+          label={label}
           onClick={() => onPageChange(currentPage - 1)}
           value={currentPage - 1}>
           Previous
@@ -108,10 +111,11 @@ class Pagination extends Component {
         )}
 
         <Button
+          action="page::next"
           category={category}
           className="next secondary"
           disabled={currentPage === totalPageCount}
-          label="Next Page"
+          label={label}
           onClick={() => onPageChange(currentPage + 1)}
           value={currentPage + 1}>
           Next
@@ -134,6 +138,7 @@ Pagination.defaultProps = {
 Pagination.propTypes = {
   category: PropTypes.string.isRequired,
   currentPage: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
   onPageChange: PropTypes.func.isRequired,
   pagesToRender: PropTypes.number,
   showPageLinks: PropTypes.bool,

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 
 
 // Component imports
+import Button from './Button'
 import Component from './Component'
 
 
@@ -19,6 +20,7 @@ class Pagination extends Component {
 
   _renderPageLinks () {
     const {
+      category,
       currentPage,
       onPageChange,
       pagesToRender,
@@ -45,12 +47,15 @@ class Pagination extends Component {
 
         pageLinks.push((
           <li key={pageNumber}>
-            <button
+            <Button
+              category={category}
               className={classes.join(', ')}
               disabled={isCurrentPage}
-              onClick={() => onPageChange(pageNumber)}>
+              label="Go To Page"
+              onClick={() => onPageChange(pageNumber)}
+              value={pageNumber}>
               {pageNumber}
-            </button>
+            </Button>
           </li>
         ))
       }
@@ -77,6 +82,7 @@ class Pagination extends Component {
 
   render () {
     const {
+      category,
       currentPage,
       onPageChange,
       showPageLinks,
@@ -85,12 +91,15 @@ class Pagination extends Component {
 
     return (
       <nav className="pagination">
-        <button
+        <Button
+          category={category}
           className="previous secondary"
           disabled={currentPage === 1}
-          onClick={() => onPageChange(currentPage - 1)}>
+          label="Previous Page"
+          onClick={() => onPageChange(currentPage - 1)}
+          value={currentPage - 1}>
           Previous
-        </button>
+        </Button>
 
         {showPageLinks && (
           <ul className="inline">
@@ -98,12 +107,15 @@ class Pagination extends Component {
           </ul>
         )}
 
-        <button
+        <Button
+          category={category}
           className="next secondary"
           disabled={currentPage === totalPageCount}
-          onClick={() => onPageChange(currentPage + 1)}>
+          label="Next Page"
+          onClick={() => onPageChange(currentPage + 1)}
+          value={currentPage + 1}>
           Next
-        </button>
+        </Button>
       </nav>
     )
   }
@@ -120,6 +132,7 @@ Pagination.defaultProps = {
 }
 
 Pagination.propTypes = {
+  category: PropTypes.string.isRequired,
   currentPage: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,
   pagesToRender: PropTypes.number,

--- a/components/TabPanel.js
+++ b/components/TabPanel.js
@@ -1,4 +1,5 @@
 // Module imports
+import Button from './Button'
 import Component from './Component'
 
 
@@ -26,6 +27,7 @@ const Tab = (props) => {
 
 const TabHeader = (props) => {
   const {
+    category,
     children,
     selectTab,
   } = props
@@ -40,12 +42,14 @@ const TabHeader = (props) => {
           } = tab.props
 
           return (
-            <button
+            <Button
+              category={category}
               className={active ? 'active' : null}
               key={title}
+              label={title}
               onClick={() => selectTab(index)}>
               {title}
-            </button>
+            </Button>
           )
         }
 

--- a/components/TrackableComponent.js
+++ b/components/TrackableComponent.js
@@ -14,7 +14,12 @@ import { pushTrackableEventToDataLayer } from '../helpers'
 
 
 // Component constants
-const gaEventProps = ['action', 'category', 'label', 'value']
+const gaEventProps = [
+  ['action', 'eventAction'],
+  ['category', 'eventCategory'],
+  ['label', 'eventLabel'],
+  ['value', 'eventValue'],
+]
 
 
 
@@ -28,9 +33,8 @@ class TrackableComponent extends Component {
   _fireEvent () {
     const eventData = {}
 
-    for (const key of gaEventProps) {
+    for (const [key, propName] of gaEventProps) {
       const value = this.props[key]
-      const propName = key.split('').reduce((accumulator, character, index) => `${accumulator}${index === 0 ? character.toUpperCase() : character}`, 'event')
 
       if (value) {
         eventData[propName] = value

--- a/components/TrackableComponent.js
+++ b/components/TrackableComponent.js
@@ -79,10 +79,7 @@ class TrackableComponent extends Component {
 
 
 
-TrackableComponent.defaultProps = {
-  label: null,
-  value: null,
-}
+TrackableComponent.defaultProps = { value: null }
 
 // We have to disable react/no-unused-prop-types here because these props are
 // used, just not in a way that ESLint can recognize.
@@ -90,7 +87,7 @@ TrackableComponent.defaultProps = {
 TrackableComponent.propTypes = {
   action: PropTypes.string.isRequired,
   category: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
   value: PropTypes.number,
 }
 /* eslint-enable */

--- a/components/TrackableComponent.js
+++ b/components/TrackableComponent.js
@@ -1,0 +1,105 @@
+// Module imports
+import PropTypes from 'prop-types'
+
+
+
+
+
+// Component imports
+import Component from './Component'
+
+
+
+
+
+// Component constants
+const gaEventProps = ['action', 'category', 'label', 'rating']
+
+
+
+
+
+class TrackableComponent extends Component {
+  /***************************************************************************\
+    Private Methods
+  \***************************************************************************/
+
+  _fireEvent () {
+    const eventData = { event: 'trackable' }
+
+    for (const key of gaEventProps) {
+      const value = this.props[key]
+      const propName = key.split('').reduce((accumulator, character, index) => `${accumulator}${index === 0 ? character.toUpperCase() : character}`, 'event')
+
+      if (value) {
+        eventData[propName] = value
+      }
+    }
+
+    TrackableComponent.dataLayer.push(eventData)
+  }
+
+
+
+
+
+  /***************************************************************************\
+    Public Methods
+  \***************************************************************************/
+
+  constructor (props) {
+    super(props)
+
+    this._bindMethods(['_fireEvent'])
+  }
+
+
+
+
+
+  /***************************************************************************\
+    Getters
+  \***************************************************************************/
+
+  static get dataLayer () {
+    return window.dataLayer || (window.dataLayer = [])
+  }
+
+  get renderProps () {
+    const renderProps = {}
+
+    for (const [key, value] of Object.entries(this.props)) {
+      if (!gaEventProps.includes(key)) {
+        renderProps[key] = value
+      }
+    }
+
+    return renderProps
+  }
+}
+
+
+
+
+
+TrackableComponent.defaultProps = {
+  label: null,
+  value: null,
+}
+
+// We have to disable react/no-unused-prop-types here because these props are
+// used, just not in a way that ESLint can recognize.
+/* eslint-disable react/no-unused-prop-types */
+TrackableComponent.propTypes = {
+  action: PropTypes.string.isRequired,
+  category: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  value: PropTypes.number,
+}
+/* eslint-enable */
+
+
+
+
+
+export default TrackableComponent

--- a/components/TrackableComponent.js
+++ b/components/TrackableComponent.js
@@ -7,13 +7,14 @@ import PropTypes from 'prop-types'
 
 // Component imports
 import Component from './Component'
+import { pushTrackableEventToDataLayer } from '../helpers'
 
 
 
 
 
 // Component constants
-const gaEventProps = ['action', 'category', 'label', 'rating']
+const gaEventProps = ['action', 'category', 'label', 'value']
 
 
 
@@ -25,7 +26,7 @@ class TrackableComponent extends Component {
   \***************************************************************************/
 
   _fireEvent () {
-    const eventData = { event: 'trackable' }
+    const eventData = {}
 
     for (const key of gaEventProps) {
       const value = this.props[key]
@@ -36,7 +37,7 @@ class TrackableComponent extends Component {
       }
     }
 
-    TrackableComponent.dataLayer.push(eventData)
+    pushTrackableEventToDataLayer(eventData)
   }
 
 
@@ -60,10 +61,6 @@ class TrackableComponent extends Component {
   /***************************************************************************\
     Getters
   \***************************************************************************/
-
-  static get dataLayer () {
-    return window.dataLayer || (window.dataLayer = [])
-  }
 
   get renderProps () {
     const renderProps = {}

--- a/components/UserProfilePanels/UserSettingsPanel.js
+++ b/components/UserProfilePanels/UserSettingsPanel.js
@@ -12,6 +12,7 @@ import React from 'react'
 // Component imports
 import { actions } from '../../store'
 import Component from '../Component'
+import Form from '../Form'
 // import ValidatedInput from '../ValidatedInput'
 import PasswordInput from '../PasswordInput'
 
@@ -184,7 +185,11 @@ class GroupSettingsPanel extends Component {
             </div>
           )}
 
-          <form onSubmit={this._handleSubmit}>
+          <Form
+            action="update"
+            category="Users"
+            label="Settings"
+            onSubmit={this._handleSubmit}>
             <fieldset>
               <label htmlFor="description">
                 Bio
@@ -265,7 +270,7 @@ class GroupSettingsPanel extends Component {
                 </button>
               </div>
             </menu>
-          </form>
+          </Form>
         </div>
       </section>
     )

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -6,6 +6,7 @@ import findAndEvaluateModifiers from './findAndEvaluateModifiers'
 import getBase64FromFileInput from './getBase64FromFileInput'
 import isUUID from './isUUID'
 import parseJSONAPIResponseForEntityType from './parseJSONAPIResponseForEntityType'
+import pushTrackableEventToDataLayer from './pushTrackableEventToDataLayer'
 
 
 
@@ -20,4 +21,5 @@ export {
   getBase64FromFileInput,
   isUUID,
   parseJSONAPIResponseForEntityType,
+  pushTrackableEventToDataLayer,
 }

--- a/helpers/pushTrackableEventToDataLayer.js
+++ b/helpers/pushTrackableEventToDataLayer.js
@@ -1,0 +1,8 @@
+export default function pushTrackableEventToDataLayer (eventData) {
+  const dataLayer = window.dataLayer || (window.dataLayer = [])
+
+  dataLayer.push({
+    event: 'trackable',
+    ...eventData,
+  })
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,9 +1,11 @@
+// Module imports
 import Document, { Head, Main, NextScript } from 'next/document'
 
 
 
 
 
+// Component constants
 const fonts = ['Lora', 'Montserrat:400,700']
 const gatmId = process.env.RFG_GOOGLE_TAG_MANAGER_API_KEY
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -54,50 +54,6 @@ export default class extends Document {
               `,
             }
           } />
-          <script dangerouslySetInnerHTML={
-            {
-              __html: `
-                window.twttr = (function(d, s, id) {
-                  var js, fjs = d.getElementsByTagName(s)[0],
-                    t = window.twttr || {};
-                  if (d.getElementById(id)) return t;
-                  js = d.createElement(s);
-                  js.id = id;
-                  js.src = "//platform.twitter.com/widgets.js";
-                  fjs.parentNode.insertBefore(js, fjs);
-
-                  t._e = [];
-                  t.ready = function(f) {
-                    t._e.push(f);
-                  };
-
-                  return t;
-                }(document, "script", "twitter-wjs"));
-              `,
-            }
-          } />
-          {/* <script dangerouslySetInnerHTML={
-            {
-              __html: `
-                window.fbAsyncInit = function() {
-                  FB.init({
-                    appId            : '${229428954285068}',
-                    autoLogAppEvents : true,
-                    xfbml            : true,
-                    version          : 'v2.12'
-                  });
-                };
-
-                (function(d, s, id){
-                  var js, fjs = d.getElementsByTagName(s)[0];
-                  if (d.getElementById(id)) {return;}
-                  js = d.createElement(s); js.id = id;
-                  js.src = "https://connect.facebook.net/en_US/sdk.js";
-                  fjs.parentNode.insertBefore(js, fjs);
-                }(document, 'script', 'facebook-jssdk'));
-              `,
-            }
-          } /> */}
         </Head>
 
         <body>

--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -7,8 +7,8 @@ import React from 'react'
 
 
 // Component imports
-import Button from '../components/Button'
 import Component from '../components/Component'
+import Form from '../components/Form'
 import Link from '../components/Link'
 import Page from '../components/Page'
 
@@ -89,7 +89,11 @@ class Login extends Component {
         )}
 
         {(['error', null].includes(status)) && (
-          <form onSubmit={this._onSubmit}>
+          <Form
+            action="reset-password"
+            category="Authentication"
+            label="Password Reset"
+            onSubmit={this._onSubmit}>
             <p><span aria-label="Castle emoji" role="img">🏰</span> Alas, traveller, we've all forgotten the keys to the castle on occasion. Enter your email address and a courier will arrive shortly with the information you need.</p>
 
             <fieldset>
@@ -112,20 +116,19 @@ class Login extends Component {
 
             <menu type="toolbar">
               <div className="primary">
-                <Button
-                  category="Forgot Password"
+                <button
                   className="success"
                   disabled={requestingReset}
-                  label="Submit Email"
                   type="submit">
                   Submit
-                </Button>
+                </button>
               </div>
 
               <div className="secondary">
                 <Link
-                  category="Sign Up"
-                  label="Return to Login"
+                  action="exit::login"
+                  category="Authentication"
+                  label="Password Reset"
                   route="/login">
                   <a className="button link">
                     Return to Login
@@ -139,7 +142,7 @@ class Login extends Component {
                 <p>There seems to have been an error when trying to reset your password. Please try again or <a href="mailto:support@rollforguild.com">contact support</a>.</p>
               </React.Fragment>
             )}
-          </form>
+          </Form>
         )}
       </React.Fragment>
     )

--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -7,7 +7,7 @@ import React from 'react'
 
 
 // Component imports
-import { Link } from '../routes'
+import Link from '../components/Link'
 import Component from '../components/Component'
 import Page from '../components/Page'
 
@@ -120,7 +120,10 @@ class Login extends Component {
               </div>
 
               <div className="secondary">
-                <Link href="/login">
+                <Link
+                  category="Sign Up"
+                  label="Return to Login"
+                  route="/login">
                   <a className="button link">
                     Return to Login
                   </a>

--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -7,8 +7,9 @@ import React from 'react'
 
 
 // Component imports
-import Link from '../components/Link'
+import Button from '../components/Button'
 import Component from '../components/Component'
+import Link from '../components/Link'
 import Page from '../components/Page'
 
 
@@ -111,12 +112,14 @@ class Login extends Component {
 
             <menu type="toolbar">
               <div className="primary">
-                <button
+                <Button
+                  category="Forgot Password"
                   className="success"
                   disabled={requestingReset}
+                  label="Submit Email"
                   type="submit">
                   Submit
-                </button>
+                </Button>
               </div>
 
               <div className="secondary">

--- a/pages/groups/create.js
+++ b/pages/groups/create.js
@@ -10,6 +10,7 @@ import Switch from 'rc-switch'
 import { Router } from '../../routes'
 import { convertStringToSlug } from '../../helpers'
 import AddressInput from '../../components/AddressInput'
+import Form from '../../components/Form'
 import Component from '../../components/Component'
 import Page from '../../components/Page'
 
@@ -123,7 +124,11 @@ class CreateGroup extends Component {
           <h1>Create a Group</h1>
         </header>
 
-        <form onSubmit={this._handleSubmit}>
+        <Form
+          action="create"
+          category="Groups"
+          label="New Group"
+          onSubmit={this._handleSubmit}>
           <fieldset>
             <label htmlFor="group-name">
               Group name
@@ -280,7 +285,7 @@ class CreateGroup extends Component {
               </button>
             </div>
           </menu>
-        </form>
+        </Form>
       </React.Fragment>
     )
   }

--- a/pages/groups/group.js
+++ b/pages/groups/group.js
@@ -19,6 +19,7 @@ import {
 } from '../../helpers'
 import { actions } from '../../store'
 import Avatar from '../../components/Avatar'
+import Button from '../../components/Button'
 import Component from '../../components/Component'
 import Page from '../../components/Page'
 import GroupDetailsPanel from '../../components/GroupProfilePanels/GroupDetailsPanel'
@@ -120,21 +121,23 @@ class JoinRequestCard extends Component {
                   Message
                 </a>
 
-                <button
+                <Button
+                  action="accept"
+                  category="Group Profile"
                   className="small success"
+                  label="Membership"
                   onClick={this._accept}>
                   Accept
-                </button>
+                </Button>
 
-                <button
+                <Button
+                  action="ignore"
+                  category="Group Profile"
                   className="small danger"
+                  label="Membership"
                   onClick={this._ignore}>
                   Ignore
-                </button>
-
-                {/* <button className="danger small">
-                  Remove
-                </button> */}
+                </Button>
               </div>
             </menu>
           )}
@@ -358,9 +361,12 @@ class GroupProfile extends Component {
           {!currentUserIsAdmin && (
             <menu type="toolbar">
               {!currentUserIsMember && (
-                <button
+                <Button
+                  action="request"
+                  category="Group Profile"
                   className="success"
                   disabled={requestingToJoin || joinRequestSent}
+                  label="Membership"
                   onClick={this._requestToJoin}>
                   {(!requestingToJoin && !joinRequestSent) && 'Request to join'}
 
@@ -371,20 +377,23 @@ class GroupProfile extends Component {
                   {requestingToJoin && (
                     <span><FontAwesomeIcon icon="spinner" pulse /> Sending request...</span>
                   )}
-                </button>
+                </Button>
               )}
 
               {currentUserIsMember && (
-                <button
+                <Button
+                  action="cancel"
+                  category="Group Profile"
                   className="danger"
                   disabled={leaving[currentUserId]}
+                  label="Membership"
                   onClick={() => this._removeMember(currentUserId)}>
                   {!leaving[currentUserId] && 'Leave group'}
 
                   {leaving[currentUserId] && (
                     <span><FontAwesomeIcon icon="spinner" pulse /> Leaving group...</span>
                   )}
-                </button>
+                </Button>
               )}
             </menu>
           )}
@@ -414,7 +423,9 @@ class GroupProfile extends Component {
             )}
           </header>
 
-          <TabPanel className="details">
+          <TabPanel
+            category="Group Profile"
+            className="details">
             <Tab title="Details">
               <GroupDetailsPanel group={group} />
             </Tab>
@@ -466,16 +477,19 @@ class GroupProfile extends Component {
 
                                 { currentUserIsAdmin && (
                                   <div className="secondary">
-                                    <button
-                                      disabled={leaving[id]}
+                                    <Button
+                                      action="remove"
+                                      category="Group Profile"
                                       className="secondary small"
+                                      disabled={leaving[id]}
+                                      label="Membership"
                                       onClick={() => this._removeMember(id)}>
                                       {!leaving[id] && 'Remove'}
 
                                       {leaving[id] && (
                                         <span><FontAwesomeIcon icon="spinner" pulse /> Removing...</span>
                                       )}
-                                    </button>
+                                    </Button>
                                   </div>
                                 )}
                               </menu>

--- a/pages/groups/group.js
+++ b/pages/groups/group.js
@@ -123,7 +123,7 @@ class JoinRequestCard extends Component {
 
                 <Button
                   action="accept"
-                  category="Group Profile"
+                  category="Groups"
                   className="small success"
                   label="Membership"
                   onClick={this._accept}>
@@ -132,7 +132,7 @@ class JoinRequestCard extends Component {
 
                 <Button
                   action="ignore"
-                  category="Group Profile"
+                  category="Groups"
                   className="small danger"
                   label="Membership"
                   onClick={this._ignore}>
@@ -363,7 +363,7 @@ class GroupProfile extends Component {
               {!currentUserIsMember && (
                 <Button
                   action="request"
-                  category="Group Profile"
+                  category="Groups"
                   className="success"
                   disabled={requestingToJoin || joinRequestSent}
                   label="Membership"
@@ -383,7 +383,7 @@ class GroupProfile extends Component {
               {currentUserIsMember && (
                 <Button
                   action="cancel"
-                  category="Group Profile"
+                  category="Groups"
                   className="danger"
                   disabled={leaving[currentUserId]}
                   label="Membership"
@@ -424,7 +424,7 @@ class GroupProfile extends Component {
           </header>
 
           <TabPanel
-            category="Group Profile"
+            category="Groups"
             className="details">
             <Tab title="Details">
               <GroupDetailsPanel group={group} />
@@ -479,7 +479,7 @@ class GroupProfile extends Component {
                                   <div className="secondary">
                                     <Button
                                       action="remove"
-                                      category="Group Profile"
+                                      category="Groups"
                                       className="secondary small"
                                       disabled={leaving[id]}
                                       label="Membership"

--- a/pages/groups/search.js
+++ b/pages/groups/search.js
@@ -290,10 +290,10 @@ class GroupSearch extends Component {
               <React.Fragment>
                 &nbsp;Perhaps you should try&nbsp;
                 <Button
-                  action="expand"
-                  category="Group Search"
+                  action="expand-distance"
+                  category="Groups"
                   className="inline link"
-                  label="Search Distance"
+                  label="Search"
                   onClick={this._incrementSearchDistance}>
                   expanding your search
                 </Button>.
@@ -310,7 +310,7 @@ class GroupSearch extends Component {
 
         {(!searching && !!groups.length) && (
           <Pagination
-            category="Group Search"
+            category="Groups"
             currentPage={pagination.currentPage}
             onPageChange={this._search}
             totalPageCount={pagination.totalPageCount} />

--- a/pages/groups/search.js
+++ b/pages/groups/search.js
@@ -9,6 +9,7 @@ import React from 'react'
 // Component imports
 import { convertObjectToQueryParams } from '../../helpers'
 import AddressInput from '../../components/AddressInput'
+import Button from '../../components/Button'
 import Component from '../../components/Component'
 import Dropdown from '../../components/Dropdown'
 import GroupCard from '../../components/GroupCard'
@@ -288,11 +289,14 @@ class GroupSearch extends Component {
             {searchDistance !== GroupSearch.searchDistances[GroupSearch.searchDistances.length - 1] && (
               <React.Fragment>
                 &nbsp;Perhaps you should try&nbsp;
-                <button
+                <Button
+                  action="expand"
+                  category="Group Search"
                   className="inline link"
+                  label="Search Distance"
                   onClick={this._incrementSearchDistance}>
                   expanding your search
-                </button>.
+                </Button>.
               </React.Fragment>
             )}
           </p>
@@ -306,6 +310,7 @@ class GroupSearch extends Component {
 
         {(!searching && !!groups.length) && (
           <Pagination
+            category="Group Search"
             currentPage={pagination.currentPage}
             onPageChange={this._search}
             totalPageCount={pagination.totalPageCount} />

--- a/pages/login.js
+++ b/pages/login.js
@@ -7,10 +7,8 @@ import React from 'react'
 
 
 // Component imports
-import {
-  Link,
-  Router,
-} from '../routes'
+import { Router } from '../routes'
+import Link from '../components/Link'
 import Component from '../components/Component'
 import Page from '../components/Page'
 
@@ -150,13 +148,19 @@ class Login extends Component {
             </div>
 
             <div className="secondary">
-              <Link href="/forgot-password">
+              <Link
+                category="Login"
+                label="Forgot Password"
+                route="/forgot-password">
                 <a className="button link">
                   Forgot Password?
                 </a>
               </Link>
 
-              <Link href="/register">
+              <Link
+                category="Login"
+                label="Sign Up"
+                route="/register">
                 <a className="button secondary">
                   Sign Up
                 </a>

--- a/pages/login.js
+++ b/pages/login.js
@@ -8,8 +8,9 @@ import React from 'react'
 
 // Component imports
 import { Router } from '../routes'
-import Link from '../components/Link'
 import Component from '../components/Component'
+import Form from '../components/Form'
+import Link from '../components/Link'
 import Page from '../components/Page'
 
 
@@ -101,7 +102,10 @@ class Login extends Component {
           <h1>Login</h1>
         </header>
 
-        <form onSubmit={this._onSubmit}>
+        <Form
+          category="Authentication"
+          label="Login"
+          onSubmit={this._onSubmit}>
           <fieldset>
             <div className="input-group">
               <label htmlFor="email">
@@ -149,8 +153,9 @@ class Login extends Component {
 
             <div className="secondary">
               <Link
-                category="Login"
-                label="Forgot Password"
+                action="exit::forgot-password"
+                category="Authentication"
+                label="Login"
                 route="/forgot-password">
                 <a className="button link">
                   Forgot Password?
@@ -158,8 +163,9 @@ class Login extends Component {
               </Link>
 
               <Link
-                category="Login"
-                label="Sign Up"
+                action="exit::register"
+                category="Authentication"
+                label="Login"
                 route="/register">
                 <a className="button secondary">
                   Sign Up
@@ -173,7 +179,7 @@ class Login extends Component {
               <p>There seems to have been an error when trying to log in to your account. Please try again or <a href="mailto:support@rollforguild.com">contact support</a>.</p>
             </React.Fragment>
           )}
-        </form>
+        </Form>
       </React.Fragment>
     )
   }

--- a/pages/my/characters.js
+++ b/pages/my/characters.js
@@ -7,7 +7,7 @@ import { Fragment } from 'react'
 
 
 // Component imports
-import { Link } from '../../routes'
+import Link from '../../components/Link'
 import Component from '../../components/Component'
 import Page from '../../components/Page'
 
@@ -60,6 +60,8 @@ class MyCharacters extends Component {
             {Object.values(characters || {}).map(character => (
               <li key={character.id}>
                 <Link
+                  category="My Characters"
+                  label="Character Card"
                   route="character profile"
                   params={{ id: character.id }}>
                   <a style={{ backgroundImage: `url(//api.adorable.io/avatars/500/${encodeURIComponent(character.id)})` }}>
@@ -71,7 +73,10 @@ class MyCharacters extends Component {
             ))}
 
             <li className="create">
-              <Link href="/character-builder">
+              <Link
+                category="My Characters"
+                label="Create New Character"
+                route="/character-builder">
                 <a>
                   <FontAwesomeIcon icon="plus" fixedWidth />
                   Add New

--- a/pages/my/groups.js
+++ b/pages/my/groups.js
@@ -6,7 +6,7 @@ import React from 'react'
 
 
 // Component imports
-import { Link } from '../../routes'
+import Link from '../../components/Link'
 import Page from '../../components/Page'
 
 
@@ -26,7 +26,7 @@ const MyGroups = () => (
       <h1>My Groups</h1>
     </header>
 
-    <p>It doesn't look like you're a part of any groups. Would you like to <Link route="group search"><a>search for groups in your area</a></Link>? Or maybe you should <Link route="group create"><a>start one</a></Link>.</p>
+    <p>It doesn't look like you're a part of any groups. Would you like to <Link category="My Groups" label="Search" route="group search"><a>search for groups in your area</a></Link>? Or maybe you should <Link category="My Groups" label="Create New Group" route="group create"><a>start one</a></Link>.</p>
   </React.Fragment>
 )
 

--- a/pages/my/groups.js
+++ b/pages/my/groups.js
@@ -26,7 +26,7 @@ const MyGroups = () => (
       <h1>My Groups</h1>
     </header>
 
-    <p>It doesn't look like you're a part of any groups. Would you like to <Link category="My Groups" label="Search" route="group search"><a>search for groups in your area</a></Link>? Or maybe you should <Link category="My Groups" label="Create New Group" route="group create"><a>start one</a></Link>.</p>
+    <p>It doesn't look like you're a part of any groups. Would you like to <Link category="Groups" label="Search" route="group search"><a>search for groups in your area</a></Link>? Or maybe you should <Link category="My Groups" label="Create New Group" route="group create"><a>start one</a></Link>.</p>
   </React.Fragment>
 )
 

--- a/pages/register.js
+++ b/pages/register.js
@@ -9,6 +9,8 @@ import React from 'react'
 // Component imports
 import { Router } from '../routes'
 import Component from '../components/Component'
+import Form from '../components/Form'
+import Link from '../components/Link'
 import Page from '../components/Page'
 
 
@@ -99,7 +101,11 @@ class Register extends Component {
         </header>
 
         {(!status && status !== 'error') && (
-          <form onSubmit={this._onSubmit}>
+          <Form
+            action="register"
+            category="Authentication"
+            label="Register"
+            onSubmit={this._onSubmit}>
             <fieldset>
               <div className="input-group">
                 <label htmlFor="email">
@@ -162,6 +168,18 @@ class Register extends Component {
                   Register
                 </button>
               </div>
+
+              <div className="secondary">
+                <Link
+                  action="exit::login"
+                  category="Authentication"
+                  label="Register"
+                  route="/login">
+                  <a className="button link">
+                    Return to Login
+                  </a>
+                </Link>
+              </div>
             </menu>
 
             {(status === 'error') && (
@@ -169,7 +187,7 @@ class Register extends Component {
                 <p>There seems to have been an error registering your account. Please try again or <a href="mailto:support@rollforguild.com">contact support</a>.</p>
               </React.Fragment>
             )}
-          </form>
+          </Form>
         )}
 
         {(status === 'success') && (

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -7,8 +7,9 @@ import React from 'react'
 
 
 // Component imports
-import Link from '../components/Link'
 import Component from '../components/Component'
+import Form from '../components/Form'
+import Link from '../components/Link'
 import Page from '../components/Page'
 
 
@@ -88,11 +89,14 @@ class Login extends Component {
         </header>
 
         {(status === 'success') && (
-          <p><span aria-label="Key emoji" role="img">🗝</span> Your password has been reset! Now take your newly minted key and go <Link category="Reset Password" label="Login" route="/login"><a>login</a></Link>!</p>
+          <p><span aria-label="Key emoji" role="img">🗝</span> Your password has been reset! Now take your newly minted key and go <Link action="exit::login" category="Authentication" label="Reset Password" route="/login"><a>login</a></Link>!</p>
         )}
 
         {['error', null].includes(status) && (
-          <form onSubmit={this._onSubmit}>
+          <Form
+            category="Authentication"
+            label="Reset Password"
+            onSubmit={this._onSubmit}>
             {!this.props.query.token && (
               <fieldset>
                 <div className="input-group">
@@ -143,8 +147,9 @@ class Login extends Component {
 
               <div className="secondary">
                 <Link
-                  category="Reset Password"
-                  label="Login"
+                  action="exit::login"
+                  category="Authentication"
+                  label="Reset Password"
                   route="/login">
                   <a className="button link">
                     Return to Login
@@ -158,7 +163,7 @@ class Login extends Component {
                 <p>There seems to have been an error while trying to reset your password. Please try again or <a href="mailto:support@rollforguild.com">contact support</a>.</p>
               </React.Fragment>
             )}
-          </form>
+          </Form>
         )}
       </React.Fragment>
     )

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -7,7 +7,7 @@ import React from 'react'
 
 
 // Component imports
-import { Link } from '../routes'
+import Link from '../components/Link'
 import Component from '../components/Component'
 import Page from '../components/Page'
 
@@ -88,7 +88,7 @@ class Login extends Component {
         </header>
 
         {(status === 'success') && (
-          <p><span aria-label="Key emoji" role="img">🗝</span> Your password has been reset! Now take your newly minted key and go <Link href="/login"><a>login</a></Link>!</p>
+          <p><span aria-label="Key emoji" role="img">🗝</span> Your password has been reset! Now take your newly minted key and go <Link category="Reset Password" label="Login" route="/login"><a>login</a></Link>!</p>
         )}
 
         {['error', null].includes(status) && (
@@ -142,7 +142,10 @@ class Login extends Component {
               </div>
 
               <div className="secondary">
-                <Link href="/login">
+                <Link
+                  category="Reset Password"
+                  label="Login"
+                  route="/login">
                   <a className="button link">
                     Return to Login
                   </a>

--- a/pages/users/user.js
+++ b/pages/users/user.js
@@ -11,7 +11,7 @@ import {
 } from '../../components/TabPanel'
 import Avatar from '../../components/Avatar'
 import Component from '../../components/Component'
-import { Link } from '../../routes'
+import Link from '../../components/Link'
 import Page from '../../components/Page'
 import UserSettingsPanel from '../../components/UserProfilePanels/UserSettingsPanel'
 
@@ -181,6 +181,8 @@ class UserProfile extends Component {
                             type="toolbar">
                             <div className="primary">
                               <Link
+                                category="User Profile"
+                                label="Group Card"
                                 route="group profile"
                                 params={{ id: group.id }}>
                                 <button

--- a/pages/users/user.js
+++ b/pages/users/user.js
@@ -151,7 +151,7 @@ class UserProfile extends Component {
           </header>
 
           <TabPanel
-            category="User Profile"
+            category="Users"
             className="details">
             <Tab title="Details">
               <section className="bio">
@@ -183,8 +183,9 @@ class UserProfile extends Component {
                             type="toolbar">
                             <div className="primary">
                               <Link
-                                category="User Profile"
-                                label="Group Card"
+                                action="view-group"
+                                category="Users"
+                                label="Group"
                                 route="group profile"
                                 params={{ id: group.id }}>
                                 <a className="button small success" >

--- a/pages/users/user.js
+++ b/pages/users/user.js
@@ -150,7 +150,9 @@ class UserProfile extends Component {
             <Avatar src={user} editable={userIsCurrentUser} />
           </header>
 
-          <TabPanel className="details">
+          <TabPanel
+            category="User Profile"
+            className="details">
             <Tab title="Details">
               <section className="bio">
                 <h4>Bio</h4>
@@ -185,10 +187,9 @@ class UserProfile extends Component {
                                 label="Group Card"
                                 route="group profile"
                                 params={{ id: group.id }}>
-                                <button
-                                  className="small success" >
+                                <a className="button small success" >
                                   View
-                                </button>
+                                </a>
                               </Link>
                             </div>
                           </menu>

--- a/routes.js
+++ b/routes.js
@@ -1,4 +1,8 @@
-const routes = (module.exports = require('next-routes')())
+const routes = require('next-routes')()
+
+
+
+
 
 routes
   // Account
@@ -19,3 +23,9 @@ routes
   // Users
   .add('user profile', '/users/:id', '/users/user')
   .add('user profile current', '/my/profile', '/users/user')
+
+
+
+
+
+module.exports = routes

--- a/routes.js
+++ b/routes.js
@@ -10,8 +10,8 @@ routes
   // Groups
   .add('group create', '/groups/create', '/groups/create')
   .add('group manage', '/groups/manage', '/groups/manage')
-  .add('group profile', '/groups/:id', '/groups/group')
   .add('group search', '/groups/search', '/groups/search')
+  .add('group profile', '/groups/:id', '/groups/group')
 
   // Password reset
   .add('password reset', '/reset(-password)?/:token?', '/reset-password')

--- a/scss/components/_application-nav-control.scss
+++ b/scss/components/_application-nav-control.scss
@@ -14,7 +14,7 @@ label[for=application-banner-control] {
   z-index: 1;
 
   @media (max-width: 1000px) {
-    &[data-openNav] {
+    &[data-opennav] {
       opacity: 1;
       pointer-events: initial;
     }
@@ -35,7 +35,7 @@ label[for=application-banner-control] {
     &:checked ~ [role=banner] {
       transform: translateX(100%);
 
-      [data-closeNav] {
+      [data-closenav] {
         margin-left: 2rem;
         opacity: 1;
         pointer-events: initial;
@@ -45,13 +45,13 @@ label[for=application-banner-control] {
     &:checked ~ [role=banner] {
       transform: translateX(100%);
 
-      [data-openNav] {
+      [data-opennav] {
         margin-left: 2rem;
         opacity: 0;
         pointer-events: none;
       }
 
-      [data-closeNav] {
+      [data-closenav] {
         opacity: 1;
         pointer-events: initial;
       }

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -11,7 +11,6 @@
 
   > .content {
     padding: 2rem;
-    display: flex;
     align-items: center;
   }
 

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -4,6 +4,7 @@
   width: 100%;
 
   ul {
+    display: flex;
     margin: 0;
 
     button {

--- a/scss/core/_headings.scss
+++ b/scss/core/_headings.scss
@@ -6,6 +6,15 @@ h4, h5, h6 {
   position: relative;
   text-transform: uppercase;
 
+  a {
+    cursor: pointer;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   sup {
     font-size: 0.5em;
     pointer-events: none;

--- a/scss/lib/_nprogress.scss
+++ b/scss/lib/_nprogress.scss
@@ -1,11 +1,11 @@
-// #nprogress {
-//   .bar {
-//     background-color: $red;
-//   }
+#nprogress {
+  .bar {
+    background-color: $green;
+  }
 
-//   .peg {
-//     box-shadow:
-//       0 0 10px $red,
-//       0 0 5px $red;
-//   }
-// }
+  .peg {
+    box-shadow:
+      0 0 10px $green,
+      0 0 5px $green;
+  }
+}


### PR DESCRIPTION
This PR presents a pretty substantial refactor. We have some new components that are light wrappers around native elements, and I've had to pretty much rewrite `<Link />`. 😞

### New components

The main difference between the new components and their native counterparts is that they have some new props and extend from the new `<TrackableComponent />`. They also pass all of their normal props down to their native counterparts.

| Prop | Examples | Description |
| --- | --- | --- |
| `category` | `Groups` | This should most often be the entity with which the action being taken is associated. If the action isn't related to a particular entity, it may be something more relevant, e.g. `Authentication`. |
| `label` | `Settings` | This is the portion of the entity that the action is being taken. |
| `action` | `request` | This is the action being taken. If the action is multiple words, it should be separated by a hyphen (-). If it has a sub-action, they should be separated by two colons, e.g. `exit::login`. |
| `value` | `100` | We don't have any uses for `value` yet, but this will eventually be used to denote things like the cost of an item being purchased, or the rating being given. |

#### `<Button />`

| Prop | Required | Default |
| --- | --- | --- |
| `category` | required | |
| `label` | required | |
| `action` | optional | `click` |
| `value` | optional | |

#### `<Form />`

| Prop | Required | Default |
| --- | --- | --- |
| `category` | required | |
| `label` | required | |
| `action` | optional | `submit` |
| `value` | optional | |

### Updated components

Some of our components needed to be updated to add tracking support.

#### `<Pagination />`

`<Pagination />` components now accept the trackable props, passing them down to the pagination buttons.

| Prop | Required | Default |
| --- | --- | --- |
| `category` | required | |
| `label` | required | |
| `action` | optional | `page::next`, `page::previous`, or `page::${pageNumber}` |
| `value` | optional | |

#### `<TabPanel />`

Similar to `<Pagination />` components, `<TabPanel />`s now accept the trackable props, passing them down to the tab buttons.

| Prop | Required | Default |
| --- | --- | --- |
| `category` | required | |
| `label` | optional | The tab's `title` prop |
| `action` | optional | `click` |
| `value` | optional | |

#### `<Link />`

Ugh. I tried everything I could think of to preserve the original `<Link / >` components, but it just wasn't happening. They all had some sort of trade-off, so I ended up going with a completely custom component that wraps `next-routes`'s `Router`.

| Prop | Required | Default |
| --- | --- | --- |
| `category` | required | |
| `label` | required | |
| `action` | optional | `click` |
| `value` | optional | |