### PR TITLE
[WEB-83] Fix account confirmation

### DIFF
--- a/pages/confirmations/account-confirm.js
+++ b/pages/confirmations/account-confirm.js
@@ -56,7 +56,7 @@ class Confirmation extends Component {
     }
   }
 
-  async componentWillMount () {
+  async componentDidMount () {
     const { loggedIn } = this.props
 
     if (loggedIn && (loggedIn !== 'error')) {


### PR DESCRIPTION
This occurred because the account confirmation action was being called on the server-side.

In the future, we should avoid doing any POST operations like this on componentWillMount, as they will now be called on both the server and the client.