### PR TITLE
[WEB-74] Fix Safari graphical glitch

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -230,7 +230,7 @@ class Nav extends Component {
         <Link
           {...itemWithOnlyLinkProps}
           category="Navigation"
-          label={renderedItemTitle}>
+          label={typeof renderedItemTitle === 'string' ? renderedItemTitle : key}>
           <a>{renderedItemTitle}</a>
         </Link>
       )

--- a/scss/components/_avatar.scss
+++ b/scss/components/_avatar.scss
@@ -31,6 +31,7 @@
   button.avatar-edit-overlay {
     align-items: center;
     background: rgba($black, .75);
+    border-radius: 50%;
     color: $white;
     display: flex;
     justify-content: center;

--- a/scss/core/_button.scss
+++ b/scss/core/_button.scss
@@ -15,6 +15,7 @@ button,
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
+  margin: 0;
   padding: 1rem 2rem;
   position: relative;
   text-decoration: none;

--- a/scss/core/_input.scss
+++ b/scss/core/_input.scss
@@ -10,6 +10,7 @@ textarea {
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
+  margin: 0;
   outline: none;
   padding: 0.5rem 1rem;
   resize: vertical;


### PR DESCRIPTION
This also fixes:

* Forms in Safari (we weren't resetting margin and borders on `<input />`s and `<button />`s)
* An error being thrown from the Nav about links receiving invalid `label` props