### PR TITLE
[WEB-144] add infrastructure for duplicate request prevention

### DIFF
--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -79,7 +79,7 @@ class Avatar extends Component {
 
     const { status } = await updateAvatar(srcType[type], id, fileBlob)
 
-    if (status !== 'success') {
+    if (status === 'error') {
       return 'File Upload Error. Please Try again.'
     }
 

--- a/components/Page.js
+++ b/components/Page.js
@@ -84,7 +84,7 @@ export default (Component, reduxOptions = {}, authenticationRequired = false) =>
       const { payload, status } = await verifySession(accessToken)
 
       // If the API returned in error, double check the reasoning.
-      if (status !== 'success') {
+      if (status === 'error') {
         if (payload && Array.isArray(payload.errors)) {
           const errMsg = payload.errors[0] && payload.errors[0].detail
 

--- a/pages/confirmations/email-update-confirm.js
+++ b/pages/confirmations/email-update-confirm.js
@@ -41,7 +41,7 @@ class Confirmation extends Component {
 
     this.setState({
       confirming: false,
-      error: status !== 'success',
+      error: status === 'error',
     })
   }
 

--- a/pages/register.js
+++ b/pages/register.js
@@ -110,7 +110,7 @@ class Register extends Component {
         </PageHeader>
 
         <Main title={title}>
-          {(!status && status !== 'error') && (
+          {!status && (
             <Form
               action="register"
               category="Authentication"

--- a/store/initialState.js
+++ b/store/initialState.js
@@ -1,31 +1,43 @@
 export default {
-
+  // Active alert objects,
   alerts: {},
 
+  // Authentication state flags
   authentication: {
     loggedIn: false,
     verifyError: false,
   },
 
+  // Avatar image data
   avatars: {
     groups: {},
     users: {},
   },
 
+  // User character data *Unused*
   characters: {},
 
+  // Group event data
   events: {},
 
+  // Game data for user, group, and event pages
   games: {},
 
+  // Group data
   groups: {},
 
+  // Game ruleset data *Unused*
   rulesets: {},
 
+  // Threads and comments of the public forums
   forums: {
     threads: {},
     comments: {},
   },
 
+  // User data
   users: {},
+
+  // Pending request data made by store action creators.
+  __pending: {},
 }

--- a/store/reducers/index.js
+++ b/store/reducers/index.js
@@ -9,7 +9,7 @@ import groups from './groups'
 import rulesets from './rulesets'
 import forums from './forums'
 import users from './users'
-
+import __pending from './pending'
 
 
 
@@ -25,4 +25,5 @@ export default combineReducers({
   groups,
   rulesets,
   users,
+  __pending,
 })

--- a/store/reducers/pending.js
+++ b/store/reducers/pending.js
@@ -1,0 +1,45 @@
+import initialState from '../initialState'
+
+
+
+
+
+export default function (state = initialState.__pending, action) {
+  const {
+    status,
+    type,
+    __aId,
+    __aArgs,
+  } = action
+
+
+  // Don't track actions which lack a tracking id
+  if (!__aId) {
+    return { ...state }
+  }
+
+  // If there is no status, just add the entry to state. We are now waiting for the resolving dispatch.
+  if (!status) {
+    return {
+      ...state,
+      [type]: {
+        ...(state[type] || {}),
+        [__aId]: __aArgs,
+      },
+    }
+  }
+
+  // If there is a status, the action has been completed and we can remove the pending status of the action.
+  const newPending = { ...state }
+  delete newPending[type][__aId]
+
+  // If there are no other open requests for this type, we can remove the type from the pending state.
+  if (!Object.values(newPending[type]).length) {
+    delete newPending[type]
+  }
+
+  return {
+    ...state,
+    [type]: newPending,
+  }
+}


### PR DESCRIPTION
This is the basis for how we will handle duplicate requests in the future. I held off adding rules to the action creators themselves for now since pages and components will require extra logic to handle the new status state. For now, however, all implicit checks for status (e.g. `status !== 'success'`) have been removed in favor of explicit checks

Fun fact.. I would reckon that the most accurate term for the function which handles our actions would be `action creator generator` since redux defines the `action` to be the object sent to `dispatch()`, and the function which prepares the actions an `action creator`. 🤔 