### PR TITLE
[WEB-127] [WEB-128] [WEB-129] Display all description fields as markdown

### DIFF
--- a/components/GroupCard.js
+++ b/components/GroupCard.js
@@ -2,15 +2,15 @@
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import React from 'react'
-
+import PropTypes from 'prop-types'
 
 
 
 // Component imports
 import { actions } from '../store'
 import Link from './Link'
-
-
+import Markdown from './Markdown'
+import Avatar from './Avatar'
 
 
 
@@ -27,9 +27,10 @@ const GroupCard = (props) => {
   return (
     <div className="card">
       <header>
+        <Avatar src={group} size="small" />
         <h2 title={name}>
           <Link
-            action="view-result"
+            action="view-group"
             category="Groups"
             label="Search"
             route="group profile"
@@ -39,24 +40,28 @@ const GroupCard = (props) => {
         </h2>
       </header>
 
-      <div className="meta">
-        <small>{members} members</small>
-      </div>
+      {members && (
+        <div className="meta">
+          <small>{members} members</small>
+        </div>
+      )}
 
       <div className="content">
-        {!!description && (
-          <p>{description}</p>
+        {Boolean(description) && (
+          <p>{<Markdown input={description} />}</p>
         )}
 
         {!description && (
-          <p><em>No description</em></p>
+          <p><em>No description available</em></p>
         )}
       </div>
     </div>
   )
 }
 
-
+GroupCard.propTypes = {
+  group: PropTypes.object.isRequired,
+}
 
 
 

--- a/pages/users/user.js
+++ b/pages/users/user.js
@@ -19,7 +19,8 @@ import PageDescription from '../../components/PageDescription'
 import PageHeader from '../../components/PageHeader'
 import PageTitle from '../../components/PageTitle'
 import UserSettingsPanel from '../../components/UserProfilePanels/UserSettingsPanel'
-
+import Markdown from '../../components/Markdown'
+import GroupCard from '../../components/GroupCard'
 
 
 
@@ -207,7 +208,13 @@ class UserProfile extends Component {
                 <section className="bio">
                   <h4>Bio</h4>
                   <div className="section-content">
-                    <p>{bio || `${username} hasn't written their bio yet!`}</p>
+                    {Boolean(bio) && (
+                      <p>{<Markdown input={bio} />}</p>
+                    )}
+
+                    {!bio && (
+                      <p><em>{`${username} hasn't written their bio yet!`}</em></p>
+                    )}
                   </div>
                 </section>
               </Tab>
@@ -223,39 +230,7 @@ class UserProfile extends Component {
 
                     {Boolean(groups.length) && (
                       <ul className="card-list">
-                        {groups.map(group => {
-                          const {
-                            description,
-                            name,
-                            slug,
-                          } = group.attributes
-
-                          return (
-                            <li
-                              className="card"
-                              key={group.id}>
-
-                              <header>
-                                <Avatar src={group} size="small" />
-
-                                <h2>
-                                  <Link
-                                    action="view-group"
-                                    category="Users"
-                                    label="Group"
-                                    route="group profile"
-                                    params={{ id: slug }}>
-                                    <a>{name}</a>
-                                  </Link>
-                                </h2>
-                              </header>
-
-                              <div className="content">
-                                {description || (<em>No description available</em>)}
-                              </div>
-                            </li>
-                          )
-                        })}
+                        {groups.map(group => (<GroupCard key={group.id} group={group} />))}
                       </ul>
                     )}
                   </section>


### PR DESCRIPTION
Additionally, also remove duplicate group card code from user profiles. 